### PR TITLE
Card Prices Update

### DIFF
--- a/script-cards.js
+++ b/script-cards.js
@@ -325,7 +325,7 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/CommandGateCards.png",
             title: "Battle Sham",
             description: "If there only are two bakugan from the same team present, one of them attcks a random adjacent enemy bakugan.",
-            price: "??? HSP"
+            price: "2,000 HSP"
         },
         {
             type: "CGC",
@@ -353,7 +353,7 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/SpecialAbilityCards.png",
             title: "Leap Sting",
             description: "An opponent's Bakugan loses 50 G's, and Laserman can attack it from anywhere on the field. If it was defeated, Laserman is returned to your hand.",
-            price: "??? HSP"
+            price: "2,750 HSP"
         }, 
 	    {
             type: "SAC",
@@ -374,7 +374,7 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/SpecialAbilityCards.png",
             title: "Dimension Four",            
             description: "Nullify the attribute gate card Reaper is standing on.",
-            price: "??? HSP"
+            price: "1,500 HSP"
         }, //Putting a non attributed version as it seems all attributes may be able to use? seen Haos, Ventus and Darkus
         {
             type: "CHGC",
@@ -388,14 +388,14 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/Anthemusa.png",
             title: "Anthemusa",
             description: "All weaker adjacent Bakugan are moved to Sirenoid's gate card and immediately defeated.",
-            price: "??? HSP"
+            price: "6,000 HSP"
         },
 	{
             type: "SAC",
             image: "./images/cards/SpecialAbilityCards.png",
             title: "Dark Sphere Impact",
             description: "An opponent's Bakugan loses -200 G's.",
-            price: "??? HSP"
+            price: "3,500 HSP"
         },
         {
             type: "NAC",
@@ -461,7 +461,7 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/CommandGateCards.png",
             title: "Additional Task",
             description: "The last Bakugan thrown on the gate card is returned to it's owner and is replaced by another Bakugan from their hand.",
-            price: "??? HSP"
+            price: "2,250 HSP"
         },
 	    {
             type: "CGC",
@@ -515,7 +515,7 @@ document.addEventListener("DOMContentLoaded", function () {
             attribute: "Haos",
             title: "Correlation - Haos & Darkus",
             description: "If there is a Darkus Bakugan on the field, your Haos Bakugan gains +100 G's. If the other Bakugan was an ally, both Bakugan gain +50 G's instead.",
-            price: "??? HSP"
+            price: "1,250 HSP"
         },
         {
             type: "NAC",
@@ -531,7 +531,7 @@ document.addEventListener("DOMContentLoaded", function () {
             attribute: "subterra",
             title: "Mega Impact",
             description: "Gorem gains +50 G's, and an opponent's Bakugan loses -100 G's.",
-            price: "??? HSP"
+            price: "4,250 HSP"
         },
 	{
             type: "SAC",
@@ -545,7 +545,7 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/SpecialAbilityCards.png",            
             title: "Face of Rage",
             description: "Fourtress gains +50 G's, and your opponent's Bakugan loses -50 G's.",
-            price: "??? HSP"
+            price: "2,500 HSP"
         },
         {
             type: "CGC",
@@ -660,7 +660,7 @@ document.addEventListener("DOMContentLoaded", function () {
             attribute: "aquos",
             title: "Dive Mirage",
             description: "Move your Aquos Bakugan to an adjacent gate card, nullifying it.",
-            price: "??? HSP"
+            price: "2,000 HSP"
         },
 	    {
             type: "NAC",
@@ -668,7 +668,7 @@ document.addEventListener("DOMContentLoaded", function () {
             attribute: "aquos",
             title: "Water Refrain",
             description: "All previous abilities used this chain are nullified.",
-            price: "??? HSP"
+            price: "3,500 HSP"
         },
         {
             type: "NAC",
@@ -705,14 +705,14 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/SpecialAbilityCards.png",
             title: "Saurus Glow",            
             description: "Saurus gains +50 G's for the rest of the battle.",
-            price: "??? HSP"
+            price: "1,250 HSP"
         },
 	    {
             type: "SAC",
             image: "./images/cards/SpecialAbilityCards.png",
             title: "Dual Gazer",            
             description: "If Dual Hydranoid is your last remaining Bakugan,it gains +50 G's and attacks two Bakugan on the field.",
-            price: "??? HSP"
+            price: "4,000 HSP"
         },
         {
             type: "NAC",
@@ -766,7 +766,7 @@ document.addEventListener("DOMContentLoaded", function () {
             title: "Water Slap",
             attribute: "aquos",
             description: "Your opponent's Bakugan loses -50 G's.",
-            price: "??? HSP"
+            price: "750 HSP"
         },
          {
             type: "NAC",
@@ -810,7 +810,7 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/SpecialAbilityCards.png",
             title: "Cut In Saber",     
 	    description: "Allows Tigrerra to enter the current battle.",
-            price: "??? HSP"
+            price: "3,500 HSP"
         },
 	    {
             type: "NAC",
@@ -840,7 +840,7 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/CommandGateCards.png",
             title: "Grand Spirit",
             description: "Your Bakugan gains +50 G's for each gate card on the field.",
-            price: "??? HSP"
+            price: "3,500 HSP"
         },
         {
             type: "NAC",
@@ -912,7 +912,7 @@ document.addEventListener("DOMContentLoaded", function () {
             title: "Spirit Canyon",
             attribute: "subterra",
             description: "Copy any power level gains from an opponent's gate card to your Bakugan",
-            price: "??? HSP"
+            price: "3,000 HSP"
         },
 	    {
             type: "NAC",
@@ -997,7 +997,7 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/CommandGateCards.png",
             title: "Level Down",
             description: "Any Bakugan on the gate card with a power level of 400 G's or higher loses -100 G's.",
-            price: "??? HSP"
+            price: "2,500 HSP"
         },
 	    {
             type: "CGC",
@@ -1011,7 +1011,7 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/CommandGateCards.png",
             title: "Revive",
             description: "The winning player revives a defeated Bakugan",
-            price: "??? HSP"
+            price: "3,000 HSP"
         }, 
         {
             type: "CGC",
@@ -1039,21 +1039,21 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/HarpusGateCards.png",
             title: "Harpus",
             description: "Harpus's power level is doubled.",
-            price: "??? HSP"
+            price: "4,000 HSP"
         },
 	    {
             type: "CHGC",
             image: "./images/cards/SkyressGateCards.png",
             title: "Skyress",
             description: "Skyress's power level is doubled.",
-            price: "??? HSP"
+            price: "4,500 HSP"
         },	
         {
             type: "CHGC",
             image: "./images/cards/LasermanGateCards.png",
             title: "Laserman",
             description: "Laserman's power level is doubled.",
-            price: "??? HSP"
+            price: "3,250 HSP"
         },
 	    {
             type: "CHGC",
@@ -1074,14 +1074,14 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/PreyasGateCards.png",
             title: "Preyas",
             description: "Preyas's power level is doubled.",
-            price: "??? HSP"
+            price: "4,000 HSP"
         },
         {
             type: "CHGC",
             image: "./images/cards/MonarusGateCards.png",
             title: "Monarus",
             description: "Monarus's power level is doubled.",
-            price: "??? HSP"
+            price: "2,750 HSP"
         },
         {
             type: "CHGC",
@@ -1095,14 +1095,14 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/FearRipperGateCards.png",
             title: "Fear Ripper",
             description: "Fear Ripper's power level is doubled.",
-            price: "??? HSP"
+            price: "2,500 HSP"
         },     
         {
             type: "CHGC",
             image: "./images/cards/RobotallionGateCards.png",
             title: "Robotallion",
             description: "Robotallion's power level is doubled.",
-            price: "??? HSP"
+            price: "2,500 HSP"
         },
         {
             type: "CHGC",
@@ -1116,7 +1116,7 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/DualHydranoidGateCards.png",
             title: "Dual Hydranoid",
             description: "Dual Hydranoid's power level is doubled.",
-            price: "??? HSP"
+            price: "6,000 HSP"
         },
 	    {
             type: "CHGC",
@@ -1144,7 +1144,7 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/CommandGateCards.png",
             title: "Energy Merge",
             description: "100 G's are transferred from the last Bakugan to stand on the gate card to the first.",
-            price: "??? HSP"
+            price: "2,750 HSP"
         },
 	    {
             type: "CGC",
@@ -1165,42 +1165,42 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/CommandGateCards.png",
             title: "Ventus Hazard",
             description: "All Bakugan on the gate card are changed to Ventus.",
-            price: "??? HSP"
+            price: "2,500 HSP"
         },
 	    {
             type: "CGC",
             image: "./images/cards/CommandGateCards.png",
             title: "Subterra Hazard",
             description: "All Bakugan on the gate card are changed to Subterra.",
-            price: "??? HSP"
+            price: "2,500 HSP"
         },
 	{
             type: "CGC",
             image: "./images/cards/CommandGateCards.png",
             title: "Pyrus Hazard",
             description: "All Bakugan on the gate card are changed to Pyrus.",
-            price: "??? HSP"
+            price: "2,500 HSP"
         },
 	    {
             type: "CGC",
             image: "./images/cards/CommandGateCards.png",
             title: "Darkus Hazard",
             description: "All Bakugan on the gate card are changed to Darkus.",
-            price: "??? HSP"
+            price: "2,500 HSP"
         },
 	    {
             type: "CGC",
             image: "./images/cards/CommandGateCards.png",
             title: "Haos Hazard",
             description: "All Bakugan on the gate card are changed to Haos.",
-            price: "??? HSP"
+            price: "2,500 HSP"
         },
 	    {
             type: "CGC",
             image: "./images/cards/CommandGateCards.png",
             title: "Supernova",
             description: "All Bakugan present on the gate cards have their power levels swapped.",
-            price: "??? HSP"
+            price: "3,500 HSP"
         },
 	    {
             type: "CGC",
@@ -1214,7 +1214,7 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/CommandGateCards.png",
             title: "Third Judgement",
             description: "The battle can only start when there are three Bakugan on the gate card, and only one Bakugan can win.",
-            price: "??? HSP"
+            price: "3,000 HSP"
         },
 	    {
             type: "CGC",
@@ -1228,14 +1228,14 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/CommandGateCards.png",
             title: "Mine Ghost",
             description: "All Bakugan present on the gate card are defeated.",
-            price: "??? HSP"
+            price: "3,000 HSP"
         },
 	    {
             type: "CGC",
             image: "./images/cards/CommandGateCards.png",
             title: "Triple Battle",
             description: "The user can add an additional Bakugan to the battle, or the battle is put on hold until there are at least three present on the gate card.",
-            price: "??? HSP"
+            price: "4,500 HSP"
         },
 	    {
             type: "CGC",
@@ -1256,7 +1256,7 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/CommandGateCards.png",
             title: "Scapegoat",
             description: "The owner of the first Bakugan to land on the gate card can decide to continue the battle or return all Bakugan present to their owner's hands.",
-            price: "??? HSP"
+            price: "3,000 HSP"
         },
 	    {
             type: "CGC",
@@ -1287,7 +1287,7 @@ document.addEventListener("DOMContentLoaded", function () {
             title: "Shadow Scratch",
             attribute: "Darkus",
             description: "Nullify the attribute gate card your Ravenoid is standing on, and an opponent's Bakugan loses -50 G's.",
-            price: "??? HSP"
+            price: "1,750 HSP"
         },
 	    {
             type: "SAC",
@@ -1318,7 +1318,7 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/SpecialAbilityCards.png",
             title: "Robotallion Enforcement",            
             description: "Robotallion gains +50 G's for the rest of the battle.",
-            price: "??? HSP"
+            price: "1,500 HSP"
         },
 	    {
             type: "SAC",
@@ -1349,21 +1349,21 @@ document.addEventListener("DOMContentLoaded", function () {
             title: "Holograph Divide",
 	    attribute: "aquos",
             description: "Your Aquos Bakugan gains +50 G's at the start of each of your turns.",
-            price: "??? HSP"
+            price: "1,500 HSP"
 	},
 	     {
             type: "SAC",
             image: "./images/cards/SpecialAbilityCards.png",
             title: "Depth Tornado",            
             description: "Juggernoid gains +100 G's.",
-            price: "??? HSP"	
+            price: "1,750 HSP"	
 	},
 	    {
             type: "SAC",
             image: "./images/cards/SpecialAbilityCards.png",
             title: "Stare Down",            
             description: "All opponent’s Bakugan adjacent to Cycloid lose -50Gs.",
-            price: "??? HSP"	
+            price: "2,000 HSP"	
 	},
 	    {
             type: "SAC",
@@ -1377,7 +1377,7 @@ document.addEventListener("DOMContentLoaded", function () {
             image: "./images/cards/SpecialAbilityCards.png",
             title: "Face of Joy",            
             description: "Immediately nullify the Gate Card Fourtress is standing on.",
-            price: "??? HSP"	
+            price: "2,500 HSP"	
 	},
 	    {
             type: "NAC",


### PR DESCRIPTION
Updated and assigned the actual value of the following cards:  Battle sham, leap sting, dimension four, anthemusa, dark sphere impact, additional task, haos darkus correlation, mega impact, face of rage, dive mirage, water refrain, saurus glow, dual gazer, water slap, cut in saber, grand spirit, spirit canyon, revive, level down, harpus, skyress, laserman, preyas, monarus, fear ripper, robotallion, dual hydranoid, energy merge, ventus hazard, subterra hazard, pyrus hazard, darkus hazard, haos hazard, supernova, third judgement, mine ghost, triple battle, scapegoat, shadow scratch, robotallion enforcement, holograph divide, depth tornado, stare down, face of joy.